### PR TITLE
Closing threads created by bot when suggestions can't be voted on anymore

### DIFF
--- a/bot/events/guild/interactionCreate.js
+++ b/bot/events/guild/interactionCreate.js
@@ -601,23 +601,27 @@ async function modalSubmit(client, modal) {
                 return message;
             });
 
-            let thread = await db.getServerAutoThread(modal.guild?.id);
-            if (thread == null) return;
-            let starterMessage = res.substring(0, 95);
-            if (starterMessage.includes(". ")) {
-                starterMessage = starterMessage.split(". ")[0];
-            }
-            if (starterMessage.includes("\n")) {
-                starterMessage = starterMessage.split("\n")[0];
-            }
-            if (starterMessage.length > 95) {
-                starterMessage += "...";
-            }
-            if (thread == true) {
+        let thread = await db.getServerAutoThread(modal.guild?.id);
+        if (thread == null) return;
+        let starterMessage = res.substring(0, 95);
+        if (starterMessage.includes(". ")) {
+            starterMessage = starterMessage.split(". ")[0];
+        }
+        if (starterMessage.includes("\n")) {
+            starterMessage = starterMessage.split("\n")[0];
+        }
+        if (starterMessage.length > 95) {
+            starterMessage += "...";
+        }
+        if (thread == true) {
+            try {
                 await sugMessage.startThread({
                     name: starterMessage,
                 });
+            } catch (e) {
+                e = null;
             }
+        }
 
     } else if (modal.customId === "edit") {
 

--- a/bot/events/guild/messageCreate.js
+++ b/bot/events/guild/messageCreate.js
@@ -164,9 +164,10 @@ module.exports = async (client, message) => {
     }
     if (thread == true) {
         try {
-            await sugMessage.startThread({
+            let threadChannel = await sugMessage.startThread({
                 name: starterMessage,
             });
+            await db.setSuggestionThread(sugMessage.id, threadChannel.id);
         } catch (e) {
             e = null;
         }

--- a/bot/events/guild/messageCreate.js
+++ b/bot/events/guild/messageCreate.js
@@ -163,9 +163,13 @@ module.exports = async (client, message) => {
         starterMessage += "...";
     }
     if (thread == true) {
-        await sugMessage.startThread({
-            name: starterMessage,
-        });
+        try {
+            await sugMessage.startThread({
+                name: starterMessage,
+            });
+        } catch (e) {
+            e = null;
+        }
     }
 };
 

--- a/bot/slashCommands/manage/suggestion.js
+++ b/bot/slashCommands/manage/suggestion.js
@@ -129,6 +129,20 @@ module.exports = {
                     {content: lang.suggest_accepted_text, ephemeral: true}
                 );
 
+                const thread = await db.getSuggestionThread(interaction.guild.id, givenMessageID.toString());
+                if (thread) {
+                    try {
+                        // get thread by id
+                        const threadChannel = await client.channels.fetch(thread);
+                        // make thread private
+                        await threadChannel.setLocked(true, "Suggestion accepted");
+                        // close thread
+                        await threadChannel.setArchived(true);
+                    } catch (e) {
+                        e = undefined
+                    }
+                }
+
             } else if (action === "decline") {
                 let embed = message.embeds[0];
                 let newEmbed = {
@@ -181,6 +195,20 @@ module.exports = {
                     {content: lang.suggest_declined_text, ephemeral: true}
                 );
 
+                const thread = await db.getSuggestionThread(interaction.guild.id, givenMessageID.toString());
+                if (thread) {
+                    try {
+                        // get thread by id
+                        const threadChannel = await client.channels.fetch(thread);
+                        // make thread private
+                        await threadChannel.setLocked(true, "Suggestion declined");
+                        // close thread
+                        await threadChannel.setArchived(true);
+                    } catch (e) {
+                        e = undefined
+                    }
+                }
+
             } else if (action === "reset") {
                 let embed = message.embeds[0];
                 let newEmbed = {
@@ -192,27 +220,41 @@ module.exports = {
                 }
 
                 await message.edit({
-                        components: [
-                            new Discord.MessageActionRow()
-                                .addComponents(
-                                    new Discord.MessageButton()
-                                        .setCustomId("up")
-                                        .setStyle("SUCCESS")
-                                        .setLabel(lang.suggest_upvote)
-                                        .setEmoji(`${uicon}`),
-                                    new Discord.MessageButton()
-                                        .setCustomId("down")
-                                        .setStyle("DANGER")
-                                        .setLabel(lang.suggest_downvote)
-                                        .setEmoji(`${dicon}`),
-                                )
-                        ],
-                        embeds: [newEmbed]
+                    components: [
+                        new Discord.MessageActionRow()
+                            .addComponents(
+                                new Discord.MessageButton()
+                                    .setCustomId("up")
+                                    .setStyle("SUCCESS")
+                                    .setLabel(lang.suggest_upvote)
+                                    .setEmoji(`${uicon}`),
+                                new Discord.MessageButton()
+                                    .setCustomId("down")
+                                    .setStyle("DANGER")
+                                    .setLabel(lang.suggest_downvote)
+                                    .setEmoji(`${dicon}`),
+                            )
+                    ],
+                    embeds: [newEmbed]
                 });
                 await db.setSuggestionPending(givenMessageID.toString(), interaction.guild.id);
                 interaction.reply(
                     {content: lang.suggest_reset_to_og_state, ephemeral: true}
                 );
+
+                const thread = await db.getSuggestionThread(interaction.guild.id, givenMessageID.toString());
+                if (thread) {
+                    try {
+                        // get thread by id
+                        const threadChannel = await client.channels.fetch(thread);
+                        // close thread
+                        await threadChannel.setArchived(false);
+                        // make thread private
+                        await threadChannel.setLocked(false, "Suggestion reset");
+                    } catch (e) {
+                        e = undefined
+                    }
+                }
             }
         } catch (e) {
             Logger.error(e);

--- a/database.js
+++ b/database.js
@@ -284,6 +284,25 @@ const getServerAutoThread = async (guildId) => {
     });
 }
 
+const getSuggestionThread = async (guildId, messageId) => {
+    return new Promise((resolve, reject) => {
+        pool.query(
+            `SELECT thread_id
+             FROM suggestions
+             WHERE server_id = ?
+               AND message_id = ?`,
+            [guildId, messageId],
+            (err, results) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(results[0]?.thread_id);
+                }
+            }
+        );
+    });
+}
+
 const setServerLanguage = async (guildId, language) => {
     return new Promise((resolve, reject) => {
         pool.query(
@@ -755,6 +774,28 @@ const setServerAutoThread = async (guildId, autoThread) => {
     });
 }
 
+const setSuggestionThread = async (suggestionId, threadId) => {
+    return new Promise((resolve, reject) => {
+        pool.query(
+            `UPDATE suggestions
+             SET thread_id = ?
+             WHERE message_id = ?`,
+            [threadId, suggestionId],
+            (err, results) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    if (results.affectedRows === 0 || results.affectedRows === undefined) {
+                        resolve(false);
+                    } else {
+                        resolve(true);
+                    }
+                }
+            }
+        );
+    });
+}
+
 const addNewSuggestion = async (guildId, suggestionId, suggestion, authorId) => {
     return new Promise((resolve, reject) => {
         // add a new suggestion to the database only if message_id is not already in the database
@@ -1002,6 +1043,7 @@ module.exports = {
     getNumberOfSuggestionsInGuild,
     getGuildsWithMostSuggestions,
     getServerAutoThread,
+    getSuggestionThread,
 
     setServerLanguage,
     setServerManagerRole,
@@ -1018,6 +1060,7 @@ module.exports = {
     setServerAutoAccept,
     setServerAutoDecline,
     setServerAutoThread,
+    setSuggestionThread,
 
     addNewSuggestion,
     addSuggestionUpvote,

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ function validateDatabase() {
                             re_voters     json      NULL,
                             creation_date timestamp NOT NULL,
                             accepted      boolean   NULL,
+                            thread_id     bigint    NULL,
                             CONSTRAINT suggestion_id PRIMARY KEY (id)
                         );`
                 , (err) => err ? logger.error(err) : resolve()));


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 90065ed</samp>

### Summary
🧵🛠️🗳️

<!--
1.  🧵 - This emoji represents threads, which are a major feature added by these changes. It can also symbolize the connection between suggestions and threads, and the improved data consistency achieved by storing the thread ID in the database.
2.  🛠️ - This emoji represents tools, which are related to the slash commands for managing suggestions and threads. It can also symbolize the improved user experience and error handling provided by these commands, and the modifications to the database schema and validation function.
3.  🗳️ - This emoji represents voting, which is the main purpose of the suggestion system. It can also symbolize the modal interaction that allows users to submit their suggestions, and the automatic thread closing and locking that happens when a suggestion is accepted or declined.
-->
This pull request enhances the bot's functionality and reliability for handling suggestions and their associated threads. It adds a new `thread_id` column to the `suggestions` table and new database functions to get and set it. It also adds or improves features for creating, closing, locking, unlocking, archiving, and unarchiving threads based on the suggestion status. It improves the error handling and data consistency of the bot by using try-catch blocks and database calls. It affects the files `bot/events/guild/interactionCreate.js`, `bot/events/guild/messageCreate.js`, `bot/slashCommands/manage/suggestion.js`, `database.js`, and `index.js`.

> _Slash the commands, unleash the threads_
> _Manage the suggestions, lock the dead_
> _Catch the errors, store the IDs_
> _Database of doom, bot of dread_

### Walkthrough
*  Add a new property to the interaction object, which is the client instance of the bot, for accessing the client methods and properties in other parts of the code ([link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-556328be7e5044ca8dafc2bb11c5dd989243abda316d51a22eeecd6a2ed4d18dR10))
*  Add a new feature to automatically close and lock the thread associated with a suggestion message when the suggestion is accepted or declined, by fetching the thread ID from the database and calling the `setLocked` and `setArchived` methods on the thread channel object, in the `checkForAutoAccept` and `checkForAutoDecline` functions in `bot/events/guild/interactionCreate.js`, and in the `/suggestion accept` and `/suggestion decline` slash commands in `bot/slashCommands/manage/suggestion.js` ([link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-556328be7e5044ca8dafc2bb11c5dd989243abda316d51a22eeecd6a2ed4d18dR131-R143), [link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-556328be7e5044ca8dafc2bb11c5dd989243abda316d51a22eeecd6a2ed4d18dR195-R207), [link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-95582a50f84a8f76ca9d8791832e8de789df8231b27795c881cf08c739f2888bR132-R145), [link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-95582a50f84a8f76ca9d8791832e8de789df8231b27795c881cf08c739f2888bR198-R211))
*  Add a new feature to automatically reopen and unlock the thread associated with a suggestion message when the suggestion is reset, by fetching the thread ID from the database and calling the `setArchived` and `setLocked` methods on the thread channel object, in the `/suggestion reset` slash command in `bot/slashCommands/manage/suggestion.js` ([link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-95582a50f84a8f76ca9d8791832e8de789df8231b27795c881cf08c739f2888bR244-R257))
*  Add error handling and data consistency to the code that starts a thread for a suggestion message, by adding a try-catch block and a call to the `setSuggestionThread` function from the database module, which stores the thread ID in the database, in the `modalSubmit` function in `bot/events/guild/interactionCreate.js`, and in the `messageCreate` event handler in `bot/events/guild/messageCreate.js` ([link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-556328be7e5044ca8dafc2bb11c5dd989243abda316d51a22eeecd6a2ed4d18dL604-R652), [link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-1828062558aee6e7688987d80dee3485f839848b25a94808c7d7dc838ab41170L166-R173))
*  Add a call to the `setSuggestionPending` function from the database module, which updates the database record of the suggestion to reflect the pending status, in the `/suggestion reset` slash command in `bot/slashCommands/manage/suggestion.js` ([link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-95582a50f84a8f76ca9d8791832e8de789df8231b27795c881cf08c739f2888bL195-R238))
*  Add a new column to the `suggestions` table in the database, which is `thread_id`, and set it to a bigint type and allow null values, for storing the thread ID associated with the suggestion message, in the `validateDatabase` function in `index.js` ([link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R61))
*  Add two new functions to the database module, which are `getSuggestionThread` and `setSuggestionThread`, for fetching and storing the thread ID associated with the suggestion message from the database, and export them from the module ([link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-c79e7bf3fe4949f3acfa89d636f82f6e794a2348c0c25763fd5fcb05a3380bb9R287-R305), [link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-c79e7bf3fe4949f3acfa89d636f82f6e794a2348c0c25763fd5fcb05a3380bb9R777-R798), [link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-c79e7bf3fe4949f3acfa89d636f82f6e794a2348c0c25763fd5fcb05a3380bb9R1046), [link](https://github.com/docimin/suggestions-bot/pull/37/files?diff=unified&w=0#diff-c79e7bf3fe4949f3acfa89d636f82f6e794a2348c0c25763fd5fcb05a3380bb9R1063))

