### PR TITLE
Update to only use message content

### DIFF
--- a/bot/guildSlashCommands/admin/guilds.js
+++ b/bot/guildSlashCommands/admin/guilds.js
@@ -82,11 +82,13 @@ module.exports = {
                     let memberCount = guild.memberCount;
                     let guildId = guild.id;
                     let guildName = guild.name;
+                    let channelCount = guild.channels.cache.size;
 
                     let guildObject = {
                         guildId: guildId,
                         guildName: guildName,
                         memberCount: memberCount,
+                        channelCount: channelCount,
                         suggestionCount: undefined,
                         invite: undefined
                     }
@@ -161,7 +163,7 @@ module.exports = {
                 await responseMessage.edit("Formatting guilds...");
 
                 const formattedGuilds = pageOneGuilds.map(guild => {
-                    return `GuildName: \`${guild.guildName}\`\nGuildId: \`${guild.guildId}\`\nMemberCount: \`${guild.memberCount}\`\nSuggestionCount: \`${guild.suggestionCount}\`\nInvite: ${guild.invite || "none"}`;
+                    return `GuildName: \`${guild.guildName}\`\nGuildId: \`${guild.guildId}\`\nMemberCount: \`${guild.memberCount}\`\nChannelCount (Cache): \`${guild.channelCount}\`\nSuggestionCount: \`${guild.suggestionCount}\`\nInvite: ${guild.invite || "none"}`;
                 });
 
                 let addFieldsObject = [];

--- a/bot/guildSlashCommands/admin/info.js
+++ b/bot/guildSlashCommands/admin/info.js
@@ -61,7 +61,7 @@ module.exports = {
             const formattedGuildsWithMostSuggestions = "" +
                 "1. " + `${client.guilds.cache.get(guildsWithMostSuggestions[0].guildId)?.name || "Unknown Guild"}` + ` (\`${guildsWithMostSuggestions[0].guildId}\`)` + " - " + guildsWithMostSuggestions[0].numberOfSuggestions + " suggestions\n" +
                 "2. " + `${client.guilds.cache.get(guildsWithMostSuggestions[1].guildId)?.name || "Unknown Guild"}` + ` (\`${guildsWithMostSuggestions[1].guildId}\`)` + " - " + guildsWithMostSuggestions[1].numberOfSuggestions + " suggestions\n" +
-                "3. " + `${client.guilds.cache.get(guildsWithMostSuggestions[2].guildId)?.name || "Unknown Guild"}` + ` (\`${guildsWithMostSuggestions[2].guildId}\`)` + " - " + guildsWithMostSuggestions[2].numberOfSuggestions + " suggestions";
+                "3. " + `${client.guilds.cache.get(guildsWithMostSuggestions[2]?.guildId)?.name || "Unknown Guild"}` + ` (\`${guildsWithMostSuggestions[2]?.guildId}\`)` + " - " + guildsWithMostSuggestions[2]?.numberOfSuggestions + " suggestions";
             //console.log(formattedGuildsWithMostSuggestions);
 
             const formattedUptime = `${Math.floor(uptime / 86400000)}d ${Math.floor(uptime / 3600000) % 24}h ${Math.floor(uptime / 60000) % 60}m ${Math.floor(uptime / 1000) % 60}s`;
@@ -118,6 +118,7 @@ module.exports = {
 
         } catch (e) {
             Logger.error(e);
+            console.trace(e);
         }
     }
 }

--- a/bot/startbot.js
+++ b/bot/startbot.js
@@ -14,7 +14,7 @@ const client = new Discord.Client({
     partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
     intents: [
         Discord.Intents.FLAGS.GUILDS,
-        Discord.Intents.FLAGS.GUILD_MEMBERS,
+        //Discord.Intents.FLAGS.GUILD_MEMBERS,
         //Discord.Intents.FLAGS.GUILD_BANS,
         //Discord.Intents.FLAGS.GUILD_EMOJIS_AND_STICKERS,
         //Discord.Intents.FLAGS.GUILD_INTEGRATIONS,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d7b9a53</samp>

### Summary
:no_entry_sign::bar_chart::bug:

<!--
1.  :no_entry_sign: for commenting out the `GUILD_MEMBERS` intent.
2.  :bar_chart: for adding the channel count of each guild.
3.  :bug: for improving the error handling and debugging.
-->
This pull request enhances the admin commands of the suggestions bot by adding channel counts to the `guilds` command, improving error handling in the `info` command, and reducing the data load from Discord by disabling the `GUILD_MEMBERS` intent in `startbot.js`.

> _We don't need the `GUILD_MEMBERS` intent_
> _We reduce the data and avoid the limit_
> _We count the channels of each guild we see_
> _We handle the errors with optional chaining_

### Walkthrough
*  Add channel count to guilds command output ([link](https://github.com/docimin/suggestions-bot/pull/40/files?diff=unified&w=0#diff-0b75e53186938d9d0959cf909c0865a7a25ccfd4526062d43174e77cf1d8191cR85), [link](https://github.com/docimin/suggestions-bot/pull/40/files?diff=unified&w=0#diff-0b75e53186938d9d0959cf909c0865a7a25ccfd4526062d43174e77cf1d8191cR91), [link](https://github.com/docimin/suggestions-bot/pull/40/files?diff=unified&w=0#diff-0b75e53186938d9d0959cf909c0865a7a25ccfd4526062d43174e77cf1d8191cL164-R166))
* Handle undefined values and errors in info command output ([link](https://github.com/docimin/suggestions-bot/pull/40/files?diff=unified&w=0#diff-019ba8ad8e9e232cae3b95617c0daf3544bc4f66beeedc8398c1b7aa1ab0a022L64-R64), [link](https://github.com/docimin/suggestions-bot/pull/40/files?diff=unified&w=0#diff-019ba8ad8e9e232cae3b95617c0daf3544bc4f66beeedc8398c1b7aa1ab0a022R121))
* Reduce data and rate limit for requesting guild members ([link](https://github.com/docimin/suggestions-bot/pull/40/files?diff=unified&w=0#diff-a8938860cc08a1af3d0b17552e846ba6eb0b8fa3dc85b20d8d9caf57b80dbf4fL17-R17))

